### PR TITLE
Added needed line for 1.4.2 migration

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -72,6 +72,8 @@ sudo su - $app <<COMMANDS
 pushd ~/live
 bin/bundle install
 yarn install --pure-lockfile
+# For 1.4.1 -> 1.4.2 migration prepare_for_foreign_keys is needed
+RAILS_ENV=production bundle exec rails mastodon:maintenance:prepare_for_foreign_keys 
 RAILS_ENV=production bundle exec rails assets:clean
 RAILS_ENV=production bundle exec rails assets:precompile
 RAILS_ENV=production bundle exec rails db:migrate


### PR DESCRIPTION
This fixes #44 
It’s not perfect as it will also run the prepare_for_foreign_keys command for future upgrades which won’t need it.
The best would be to add a condition and only run it if migrating from <1.4.2 to >=1.4.2.