### PR TITLE
Add a check that there's a reasonable quantity of RAM+swap available

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mastodon for YunoHost
 
-[![Latest Version](https://img.shields.io/badge/version-2.5.1-green.svg?style=flat)](https://github.com/YunoHost-Apps/mastodon_ynh/releases)
+[![Latest Version](https://img.shields.io/badge/version-2.5.2-green.svg?style=flat)](https://github.com/YunoHost-Apps/mastodon_ynh/releases)
 [![Status](https://img.shields.io/badge/status-testing-yellow.svg?style=flat)](https://github.com/YunoHost-Apps/mastodon_ynh/milestones)
 [![Dependencies](https://img.shields.io/badge/dependencies-includes-lightgrey.svg?style=flat)](https://github.com/YunoHost-Apps/mastodon_ynh#dependencies)
 [![GitHub license](https://img.shields.io/badge/license-GPLv3-blue.svg?style=flat)](https://raw.githubusercontent.com/YunoHost-Apps/mastodon_ynh/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mastodon for YunoHost
 
-[![Latest Version](https://img.shields.io/badge/version-2.5.0-green.svg?style=flat)](https://github.com/YunoHost-Apps/mastodon_ynh/releases)
+[![Latest Version](https://img.shields.io/badge/version-2.5.1-green.svg?style=flat)](https://github.com/YunoHost-Apps/mastodon_ynh/releases)
 [![Status](https://img.shields.io/badge/status-testing-yellow.svg?style=flat)](https://github.com/YunoHost-Apps/mastodon_ynh/milestones)
 [![Dependencies](https://img.shields.io/badge/dependencies-includes-lightgrey.svg?style=flat)](https://github.com/YunoHost-Apps/mastodon_ynh#dependencies)
 [![GitHub license](https://img.shields.io/badge/license-GPLv3-blue.svg?style=flat)](https://raw.githubusercontent.com/YunoHost-Apps/mastodon_ynh/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mastodon for YunoHost
 
-[![Latest Version](https://img.shields.io/badge/version-2.4.5-green.svg?style=flat)](https://github.com/YunoHost-Apps/mastodon_ynh/releases)
+[![Latest Version](https://img.shields.io/badge/version-2.5.0-green.svg?style=flat)](https://github.com/YunoHost-Apps/mastodon_ynh/releases)
 [![Status](https://img.shields.io/badge/status-testing-yellow.svg?style=flat)](https://github.com/YunoHost-Apps/mastodon_ynh/milestones)
 [![Dependencies](https://img.shields.io/badge/dependencies-includes-lightgrey.svg?style=flat)](https://github.com/YunoHost-Apps/mastodon_ynh#dependencies)
 [![GitHub license](https://img.shields.io/badge/license-GPLv3-blue.svg?style=flat)](https://raw.githubusercontent.com/YunoHost-Apps/mastodon_ynh/master/LICENSE)

--- a/conf/app-mastodon.src
+++ b/conf/app-mastodon.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/tootsuite/mastodon/archive/v2.4.5.tar.gz
-SOURCE_SUM=9e8cf6a808c9c34b6b609e8acc86b91a02227580b61221d96a4b78560fcc592c
+SOURCE_URL=https://github.com/tootsuite/mastodon/archive/v2.5.0.tar.gz
+SOURCE_SUM=0b36693058647ab50fff7f1c0c678f0f2b2997908c542c488386e8e16beced74
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/app-mastodon.src
+++ b/conf/app-mastodon.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/tootsuite/mastodon/archive/v2.5.0.tar.gz
-SOURCE_SUM=0b36693058647ab50fff7f1c0c678f0f2b2997908c542c488386e8e16beced74
+SOURCE_URL=https://github.com/tootsuite/mastodon/archive/v2.5.1.tar.gz
+SOURCE_SUM=452f6a4eb562bc1d6c49cbf94c7a2dfa16b2f38d47b77cc25737164479474043
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/app-mastodon.src
+++ b/conf/app-mastodon.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/tootsuite/mastodon/archive/v2.5.1.tar.gz
-SOURCE_SUM=452f6a4eb562bc1d6c49cbf94c7a2dfa16b2f38d47b77cc25737164479474043
+SOURCE_URL=https://github.com/tootsuite/mastodon/archive/v2.5.2.tar.gz
+SOURCE_SUM=d25e432f1fcf223270414dd55be4d2878f1af86c21b1f2d7874fa1c57d75ebfb
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
 		"en": "Mastodon is a free, open-source social network.",
 		"fr": "Mastodon est un réseau social gratuit et open source."
 	},
-	"version": "2.4.5",
+	"version": "2.5.0",
 	"url": "https://github.com/tootsuite/mastodon",
 	"license": "AGPL-3.0-or-later",
 	"maintainer": {

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
 		"en": "Mastodon is a free, open-source social network.",
 		"fr": "Mastodon est un réseau social gratuit et open source."
 	},
-	"version": "2.5.1",
+	"version": "2.5.2",
 	"url": "https://github.com/tootsuite/mastodon",
 	"license": "AGPL-3.0-or-later",
 	"maintainer": {

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
 		"en": "Mastodon is a free, open-source social network.",
 		"fr": "Mastodon est un réseau social gratuit et open source."
 	},
-	"version": "2.5.0",
+	"version": "2.5.1",
 	"url": "https://github.com/tootsuite/mastodon",
 	"license": "AGPL-3.0-or-later",
 	"maintainer": {

--- a/scripts/install
+++ b/scripts/install
@@ -42,6 +42,12 @@ test ! -e "$final_path" || ynh_die "This path already contains a folder"
 # TODO: remove this test, don't as password anymore, generate it and send it by email to admin with: https://github.com/YunoHost-Apps/Experimental_helpers/tree/master/send_readme_to_admin
 [[ ${#admin_pass} -gt 7 ]] || ynh_die "Password is too weak, must be longer than 7 characters"
 
+MEM=$(free | grep "^Mem"  | awk '{print $2}')
+SWAP=$(free | grep "^Swap" | awk '{print $2}')
+TOTAL_MEM_AND_SWAP=$(( ( $MEM+$SWAP ) / 1024 )) # In MB
+
+[[ $TOTAL_MEM_AND_SWAP -gt 2500 ]] || ynh_die "You need at least 2500 Mo of RAM+Swap to install Mastodon. Please consult the README to learn how to add swap."
+
 # Normalize the url path syntax
 path_url=$(ynh_normalize_url_path $path_url)
 

--- a/scripts/install
+++ b/scripts/install
@@ -94,7 +94,7 @@ ynh_app_setting_set "$app" final_path "$final_path"
 # TODO: use https://github.com/YunoHost-Apps/Experimental_helpers/blob/master/ynh_install_nodejs/ynh_install_nodejs
 (
 	cd /opt
-	curl -sL https://deb.nodesource.com/setup_6.x | bash -
+	curl -sL https://deb.nodesource.com/setup_8.x | bash -
 	apt-get -y install nodejs
 )
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -99,7 +99,7 @@ ynh_package_update
 # TODO: use https://github.com/YunoHost-Apps/Experimental_helpers/blob/master/ynh_install_nodejs/ynh_install_nodejs
 (
 	cd /opt
-	curl -sL https://deb.nodesource.com/setup_6.x | bash -
+	curl -sL https://deb.nodesource.com/setup_8.x | bash -
 	apt-get -y install nodejs
 )
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -104,10 +104,9 @@ ynh_package_install pkg-config libprotobuf-dev protobuf-compiler libicu-dev libi
 chown -R $app: $final_path/live
 
 # Stop Mastodon Services
-# Restart Mastodon
-yunohost service stop "$app-web"
-yunohost service stop "$app-sidekiq"
-yunohost service stop "$app-streaming"
+#yunohost service stop "$app-web"
+#yunohost service stop "$app-sidekiq"
+#yunohost service stop "$app-streaming"
 
 # Download Mastodon
 ynh_setup_source "$final_path/live"                      "app-mastodon"
@@ -170,19 +169,30 @@ popd
 
 sudo su - $app <<COMMANDS
 pushd ~/live
-RAILS_ENV=production $final_path/.rbenv/versions/2.5.1/bin/bundle exec rails db:migrate
+SKIP_POST_DEPLOYMENT_MIGRATIONS=true RAILS_ENV=production $final_path/.rbenv/versions/2.5.1/bin/bundle exec rails db:migrate
 COMMANDS
 )
 #=================================================
 # RESTART MASTODON
 #=================================================
 
+yunohost service stop "$app-web"
+yunohost service stop "$app-sidekiq"
+yunohost service stop "$app-streaming"
 yunohost service start "$app-web"
 yunohost service start "$app-sidekiq"
 yunohost service start "$app-streaming"
 
 # Waiting start all services
 sleep 30
+#=================================================
+# DB:Migrate after restart 2.5.0
+#=================================================
+
+sudo su - $app <<COMMANDS
+pushd ~/live
+RAILS_ENV=production $final_path/.rbenv/versions/2.5.1/bin/bundle exec rails db:migrate
+COMMANDS
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -86,14 +86,12 @@ echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.lis
 # INSTALL DEPENDENCIES
 #=================================================
 
-# upgrade Node.js v4 to v6
+# upgrade Node.js to v8
 # TODO: use https://github.com/YunoHost-Apps/Experimental_helpers/blob/master/ynh_install_nodejs/ynh_install_nodejs
-node_version=$(nodejs --version)
-if [[ $node_version =~ ^v4.*$  ]]; then
-	pushd /opt
-	curl -sL https://deb.nodesource.com/setup_6.x | sudo bash -
-	sudo apt-get -y install nodejs
-fi
+pushd /opt
+curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
+sudo apt-get -y install nodejs
+popd
 
 # add additional package for upgrade
 ynh_package_install pkg-config libprotobuf-dev protobuf-compiler libicu-dev libidn11-dev postgresql-server-dev-all


### PR DESCRIPTION
Suggesting to add this check at the beginning of the install script so that people trying to naively install this app get this info directly instead of encountering the whole ruby stacktrace complaining that `virtual memory exhausted: Cannot allocate memory` :wink: 

N.B. : I only tested these few lines using a small bash script (not running the `yunohost install` itself) ...