### PR TITLE
Add a check that there's a reasonable quantity of RAM+swap available

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -40,6 +40,13 @@ app=$YNH_APP_INSTANCE_NAME
 final_path=/var/www/$app
 test ! -e "$final_path" || ynh_die "This path already contains a folder"
 
+# TODO : to be factorized into a helper someday ? ;)
+MEM=$(free | grep "^Mem"  | awk '{print $2}')
+SWAP=$(free | grep "^Swap" | awk '{print $2}')
+TOTAL_MEM_AND_SWAP=$(( ( $MEM+$SWAP ) / 1024 )) # In MB
+
+[[ $TOTAL_MEM_AND_SWAP -gt 2500 ]] || ynh_die "You need at least 2500 Mo of RAM+Swap to install Mastodon. Please consult the README to learn how to add swap."
+
 # Normalize the url path syntax
 path_url=$(ynh_normalize_url_path $path_url)
 


### PR DESCRIPTION
(Uhoh, messed up something while trying to push my branch and deleted it instead ... here's a new PR, re-copypasting original description) 

Suggesting to add this check at the beginning of the install script so that people trying to naively install this app get this info directly instead of encountering the whole ruby stacktrace complaining that `virtual memory exhausted: Cannot allocate memory` :wink: 

N.B. : I only tested these few lines using a small bash script (not running the `yunohost install` itself) ...