### PR TITLE
There's a stupid super weird bug if there's no quote here (though fixed in 3.8 I think)

### DIFF
--- a/scripts/ynh_add_extra_apt_repos__3
+++ b/scripts/ynh_add_extra_apt_repos__3
@@ -128,7 +128,7 @@ ynh_install_extra_repo () {
 	local component="${repo##$uri $suite }"
 
 	# Add the repository into sources.list.d
-	ynh_add_repo --uri="$uri" --suite="$suite" --component="$component" --name="$name" $append
+	ynh_add_repo --uri="$uri" --suite="$suite" --component="$component" --name="$name" "$append"
 
 	# Pin the new repo with the default priority, so it won't be used for upgrades.
 	# Build $pin from the uri without http and any sub path
@@ -139,7 +139,7 @@ ynh_install_extra_repo () {
 	then
 		priority="--priority=$priority"
 	fi
-	ynh_pin_repo --package="*" --pin="origin \"$pin\"" $priority --name="$name" $append
+	ynh_pin_repo --package="*" --pin="origin \"$pin\"" $priority --name="$name" "$append"
 
 	# Get the public key for the repo
 	if [ -n "$key" ]


### PR DESCRIPTION

## Problem

c.f. https://forum.yunohost.org/t/mastodon-install-error/11470/2

## Solution

same as here https://github.com/YunoHost-Apps/codimd_ynh/pull/19#issuecomment-619669179

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/mastodon_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/mastodon_ynh%20PR-NUM-%20(USERNAME)/)  
