### PR TITLE
Fix nginx.conf for multi-instance

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -38,7 +38,7 @@ location @proxy {
   proxy_set_header Proxy "";
   proxy_pass_header Server;
 
-  proxy_pass http://127.0.0.1:3000;
+  proxy_pass http://127.0.0.1:__PORT_WEB__;
   proxy_buffering on;
   proxy_redirect off;
   proxy_http_version 1.1;
@@ -62,7 +62,7 @@ location /api/v1/streaming {
   proxy_set_header X-Forwarded-Proto https;
   proxy_set_header Proxy "";
 
-  proxy_pass http://127.0.0.1:4000;
+  proxy_pass http://127.0.0.1:__PORT_STREAM__;
   proxy_buffering off;
   proxy_redirect off;
   proxy_http_version 1.1;


### PR DESCRIPTION
## Problem
`nginx.conf` uses hardcoded port numbers.

## Solution
Use `__PORT_WEB__` and `__PORT_STREAM__` in `nginx.conf`.

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.
