### PR TITLE
perf(upgrade): use mv in place of rsync for system directory

### DIFF
--- a/README_fr.md
+++ b/README_fr.md
@@ -1,24 +1,24 @@
 # Mastodon pour YunoHost
 
-[![Integration level](https://dash.yunohost.org/integration/mastodon.svg)](https://dash.yunohost.org/appci/app/mastodon)  
+[![Integration level](https://dash.yunohost.org/integration/mastodon.svg)](https://dash.yunohost.org/appci/app/mastodon) ![](https://ci-apps.yunohost.org/ci/badges/mastodon.status.svg) ![](https://ci-apps.yunohost.org/ci/badges/mastodon.maintain.svg)    
 [![Install Mastodon with YunoHost](https://install-app.yunohost.org/install-with-yunohost.png)](https://install-app.yunohost.org/?app=mastodon)
 
 *[Read this readme in english.](./README.md)* 
 
-> *Ce package vous permet d'installer Mastodon rapidement et simplement sur un serveur Yunohost.  
+> *Ce package vous permet d'installer Mastodon rapidement et simplement sur un serveur YunoHost.  
 Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour savoir comment l'installer et en profiter.*
 
 ## Vue d'ensemble
-Mastodon est un réseau social gratuit et open source. Une alternative décentralisée aux plates-formes commerciales, elle évite les risques d'une seule société qui monopolise votre communication.
+Mastodon est un réseau social de microblog auto-hébergé et open source. C'est une alternative décentralisée aux plates-formes commerciales comme Twitter. Mastodon évite ainsi les risques qu'une seule société monopolise votre communication à des fins commerciales.
 
 **Version incluse:** 3.1.2
 
 ## Points importants à lire avant l'installation
 
-1. **Mastodon** nécessite un **nom de domaine** dédié, par exemple: mastodon.domain.tld
+1. **Mastodon** nécessite un **nom de domaine** dédié, par exemple : mastodon.domain.tld
 1. L'utilisateur sélectionné pendant l'installation sera créé automatiquement dans Mastodon avec des droits d'administration.
-1. A la fin de l'installation, un mail est envoyé à cet utilisateur avec le mot de passe qui a été généré automatiquement.
-1. Il semble important de fermer les inscriptions pour votre Mastodon, pour que Ã§a reste une instance privÃ©. Nous vous invitons Ã  bloquer les instances distantes malfaisantes depuis l'interface d'administration. Vous pouvez Ã©galement ajouter un texte sur votre page d'accueil dans l'administration.
+1. À la fin de l'installation, un mail est envoyé à cet utilisateur avec un mot de passe généré automatiquement.
+1. Pour que votre instance Mastodon reste privée, il est important de fermer les inscriptions. Nous vous invitons à bloquer les instances distantes indésirables depuis l'interface d'administration. Vous pouvez également ajouter un texte sur votre page d'accueil dans l'administration.
 
 ## Captures d'écran
 
@@ -28,28 +28,28 @@ Mastodon est un réseau social gratuit et open source. Une alternative décentra
 
 ### Installation
 
-#### Utilisation de __screen__ en cas de dÃ©connection
+#### Utilisation de *screen* en cas de déconnection
 ```
 $ sudo apt-get install screen
 $ screen
 $ sudo yunohost app install https://github.com/YunoHost-Apps/mastodon_ynh.git
 ```
-RÃ©cuperer l'installation aprÃ¨s une deconnection:
+Récupérer l'installation après une deconnection :
 ```
 $ screen -d
 $ screen -r
 ```
-L'utilisateur admin est crÃ©e automatiquement comme: user@domain.tld
+L'utilisateur admin est créé automatiquement comme : user@domain.tld
 
-### Mise Ã jour
+### Mise à jour
 
-#### Utilisation de __screen__ fortement recommandÃ©
+#### Utilisation de *screen* fortement recommandée
 
 `$ sudo yunohost app upgrade mastodon -u https://github.com/YunoHost-Apps/mastodon_ynh --debug `
 
 ## Documentation
 
- * Documentation officielle: https://docs.joinmastodon.org/
+ * Documentation officielle : https://docs.joinmastodon.org/
 
 ## Caractéristiques spécifiques YunoHost
 
@@ -59,15 +59,15 @@ L'authentification LDAP est activée. Tous les utilisateurs YunoHost peuvent s'a
 
 #### Architectures supportées
 
-* x86-64b - [![Build Status](https://ci-apps.yunohost.org/ci/logs/mastodon%20%28Apps%29.svg)](https://ci-apps.yunohost.org/ci/apps/mastodon/)
+* x86-64 - [![Build Status](https://ci-apps.yunohost.org/ci/logs/mastodon%20%28Apps%29.svg)](https://ci-apps.yunohost.org/ci/apps/mastodon/)
 * ARMv8-A - [![Build Status](https://ci-apps-arm.yunohost.org/ci/logs/mastodon%20%28Apps%29.svg)](https://ci-apps-arm.yunohost.org/ci/apps/mastodon/)
 
 ## Links
 
- * Signaler un bug: https://github.com/YunoHost-Apps/mastodon_ynh/issues
- * Site de l'application: https://joinmastodon.org/
- * Dépôt de l'application principale: https://github.com/tootsuite/mastodon
- * Site web YunoHost: https://yunohost.org/
+ * Signaler un bug : https://github.com/YunoHost-Apps/mastodon_ynh/issues
+ * Site de l'application : https://joinmastodon.org/
+ * Dépôt de l'application principale : https://github.com/tootsuite/mastodon
+ * Site web YunoHost : https://yunohost.org/
 
 ---
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -179,7 +179,7 @@ then
 
 	mkdir $tmpdir/system
 	if [ -d "$final_path/live/public/system" ]; then
-		rsync -a "$final_path/live/public/system" "$tmpdir/."
+		mv --verbose --no-target-directory --backup=numbered "$final_path/live/public/system" "$final_path/system.tmp"
 	fi
 	rsync -a "$config" "$tmpdir/."
 	ynh_secure_remove --file="$final_path/live"
@@ -188,8 +188,8 @@ then
 	# Temporary workaround for https://github.com/tootsuite/mastodon/issues/13292
 	ynh_replace_string --match_string="sidekiq-unique-jobs (6.0.18)" --replace_string="sidekiq-unique-jobs (6.0.20)" --target_file="$final_path/live/Gemfile.lock"
 
-	if [ -d "$tmpdir/system" ]; then
-		rsync -a "$tmpdir/system" "$final_path/live/public/."
+	if [ -d "$final_path/system.tmp" ]; then
+		mv --verbose --no-target-directory "$final_path/system.tmp" "$final_path/live/public/system"
 	fi
 	rsync -a "$tmpdir/.env.production" "$final_path/live/."
 	ynh_secure_remove --file="$tmpdir"


### PR DESCRIPTION
## Problem
Try to fix #175 

## Solution
- Use `mv` in place of `rsync` for `public/system/` directory

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/mastodon_ynh%20PR231%20(yalh76)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/mastodon_ynh%20PR231%20(yalh76)/)  

![image](https://user-images.githubusercontent.com/30271971/86975506-bed3a880-c178-11ea-9e76-7d935b2f5cdd.png)

