### PR TITLE
LOAD_NODE -> NODE_LOAD

### DIFF
--- a/conf/mastodon-streaming.service
+++ b/conf/mastodon-streaming.service
@@ -9,7 +9,7 @@
  Environment="NODE_ENV=production"
  Environment="PORT=__PORT_STREAM__"
  Environment="STREAMING_CLUSTER_NUM=1"
- Environment=__YNH_LOAD_NODE_PATH__
+ Environment="__YNH_NODE_LOAD_PATH__"
  ExecStart=__YNH_NODE__ ./streaming
  TimeoutSec=15
  Restart=always


### PR DESCRIPTION
## Problem
- *The  string `__YNH_LOAD_NODE_PATH__` in the streaming service is not replaced*

## Solution
- *Change it to `__YNH_NODE_LOAD_PATH__` because the corresponding variable is `ynh_node_load_PATH`*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/mastodon_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/mastodon_ynh%20PR-NUM-%20(USERNAME)/)  
