### PR TITLE
[fix] Set REDIS_NAMESPACE for multiple instances

### DIFF
--- a/conf/.env.production.sample
+++ b/conf/.env.production.sample
@@ -14,6 +14,7 @@ LOCAL_DOMAIN=__DOMAIN__
 # -----
 REDIS_HOST=localhost
 REDIS_PORT=6379
+REDIS_NAMESPACE=__REDIS_NAMESPACE__
 
 # PostgreSQL
 # ----------

--- a/scripts/install
+++ b/scripts/install
@@ -162,6 +162,9 @@ config="$final_path/live/.env.production"
 
 language="$(echo $language | head -c 2)"
 
+redis_namespace=${app}_production
+ynh_app_setting_set --app="$app" --key=redis_namespace --value="$redis_namespace"
+
 secret_key_base=$(ynh_string_random --length=128)
 ynh_app_setting_set --app="$app" --key=secret_key_base --value="$secret_key_base"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -23,6 +23,7 @@ path_url=$(ynh_app_setting_get --app=$app --key=path)
 admin=$(ynh_app_setting_get --app=$app --key=admin)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 language=$(ynh_app_setting_get --app=$app --key=language)
+redis_namespace=$(ynh_app_setting_get --app=$app --key=db_name)
 db_name=$(ynh_app_setting_get --app=$app --key=db_name)
 db_user=$(ynh_sanitize_dbid --db_name=$app)
 db_pwd=$(ynh_app_setting_get --app=$app --key=db_pwd)
@@ -109,6 +110,12 @@ if [[ -z "$vapid_private_key" ]]; then
 	vapid_public_key=$(grep -oP "VAPID_PUBLIC_KEY=\K.+" $config)
 	ynh_app_setting_set "$app" vapid_private_key "$vapid_private_key"
 	ynh_app_setting_set "$app" vapid_public_key "$vapid_public_key"
+fi
+
+# If redis_namespace doesn't exist, create it
+if [[ -z "$redis_namespace" ]]; then
+	redis_namespace=${app}_production
+	ynh_app_setting_set --app=$app --key=redis_namespace --value=$redis_namespace
 fi
 
 #Remove previous added repository


### PR DESCRIPTION
## Problem

- Now, multiple instances on the same server use the same redis namespace, which cause issues in timelines.

## Solution

- Set `REDIS_NAMESPACE` in `.env.production`

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
