### PR TITLE
[enh] Enable SSO

### DIFF
--- a/doc/DISCLAIMER.md
+++ b/doc/DISCLAIMER.md
@@ -36,3 +36,5 @@ $ screen -r
 #### Multi-users support
 
 LDAP authentication is activated. All YunoHost users can authenticate.
+
+Log-out from YunoHost's portal doesn't log out from Mastodon. See https://github.com/YunoHost/issues/issues/501

--- a/doc/DISCLAIMER_fr.md
+++ b/doc/DISCLAIMER_fr.md
@@ -36,12 +36,10 @@ L'utilisateur admin est créé automatiquement comme : user@domain.tld
 
 `$ (cd /var/www/mastodon/live && sudo -u mastodon RAILS_ENV=production PATH=/opt/rbenv/versions/mastodon/bin bin/tootctl --help)`
 
-## Documentation
-
- * Documentation officielle : https://docs.joinmastodon.org/
-
 ## Caractéristiques spécifiques YunoHost
 
 #### Support multi-utilisateur
 
 L'authentification LDAP est activée. Tous les utilisateurs YunoHost peuvent s'authentifier.
+
+Se déconnecter depuis le portail YunoHost ne vous déconnecte pas de Mastodon. Voir https://github.com/YunoHost/issues/issues/501

--- a/sources/patches/app-sso.patch
+++ b/sources/patches/app-sso.patch
@@ -1,0 +1,56 @@
+diff --git a/app/controllers/application_controller.rb b/app/controllers/application_controller.rb
+index 7c36bc6b8..3f691d102 100644
+--- a/app/controllers/application_controller.rb
++++ b/app/controllers/application_controller.rb
+@@ -69,7 +69,7 @@ class ApplicationController < ActionController::Base
+   end
+ 
+   def after_sign_out_path_for(_resource_or_scope)
+-    new_user_session_path
++    "https://#{File.read('/etc/yunohost/current_host')}/yunohost/sso/?action=logout"
+   end
+ 
+   protected
+diff --git a/config/initializers/devise.rb b/config/initializers/devise.rb
+index 5232e6cfd..160348674 100644
+--- a/config/initializers/devise.rb
++++ b/config/initializers/devise.rb
+@@ -180,7 +180,7 @@ Devise.setup do |config|
+   # given strategies, for example, `config.http_authenticatable = [:database]` will
+   # enable it only for database authentication. The supported strategies are:
+   # :database      = Support basic authentication with authentication key + password
+-  config.http_authenticatable = [:pam, :database]
++  config.http_authenticatable = [:two_factor_ldap, :pam, :database]
+ 
+   # If 401 status code should be returned for AJAX requests. True by default.
+   # config.http_authenticatable_on_xhr = true
+diff --git a/lib/devise/two_factor_ldap_authenticatable.rb b/lib/devise/two_factor_ldap_authenticatable.rb
+index 065aa2de8..0eb4be10c 100644
+--- a/lib/devise/two_factor_ldap_authenticatable.rb
++++ b/lib/devise/two_factor_ldap_authenticatable.rb
+@@ -5,13 +5,13 @@ require 'devise/strategies/base'
+ 
+ module Devise
+   module Strategies
+-    class TwoFactorLdapAuthenticatable < Base
++    class TwoFactorLdapAuthenticatable < Authenticatable
+       def valid?
+-        valid_params? && mapping.to.respond_to?(:authenticate_with_ldap)
++        (valid_for_params_auth? || valid_for_http_auth?) && mapping.to.respond_to?(:authenticate_with_ldap)
+       end
+ 
+       def authenticate!
+-        resource = mapping.to.authenticate_with_ldap(params[scope])
++        resource = mapping.to.authenticate_with_ldap(authentication_hash.merge(:password => password))
+ 
+         if resource && !resource.otp_required_for_login?
+           success!(resource)
+@@ -23,7 +23,7 @@ module Devise
+       protected
+ 
+       def valid_params?
+-        params[scope] && params[scope][:password].present?
++        super && params[scope][:password].present?
+       end
+     end
+   end


### PR DESCRIPTION
## Problem

- SSO doesn't work

## Solution

- Patch Devise config to use `http_auth` with `TwoFactorLdapAuthenticatable`
- Patch `TwoFactorLdapAuthenticatable` to accept http_auth (https://github.com/cschiewek/devise_ldap_authenticatable/blob/default/lib/devise_ldap_authenticatable/strategy.rb#L13 https://github.com/heartcombo/devise/blob/main/lib/devise/strategies/authenticatable.rb#L18
- Patch `after_sign_out` redirection to SSO log out page

## PR Status

I tested this with `domain.tld` as main domain and Mastodon installed at `mastodon.domain.tld`

A known issue : Log-out from YunoHost's portal doesn't log out from Mastodon. See https://github.com/YunoHost/issues/issues/501

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested

## Automatic tests

[![Test Badge](https://img.shields.io/endpoint?url=https://bleu.cant.at/ci/api/job/8/badge)](https://bleu.cant.at/ci/job/8)
[![](https://bleu.cant.at/ci/summary/8.png)](https://bleu.cant.at/ci/job/8)