### PR TITLE
Update 3.4.5

### DIFF
--- a/.github/workflows/updater.sh
+++ b/.github/workflows/updater.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+#=================================================
+# PACKAGE UPDATING HELPER
+#=================================================
+
+# This script is meant to be run by GitHub Actions
+# The YunoHost-Apps organisation offers a template Action to run this script periodically
+# Since each app is different, maintainers can adapt its contents so as to perform
+# automatic actions when a new upstream release is detected.
+
+#=================================================
+# FETCHING LATEST RELEASE AND ITS ASSETS
+#=================================================
+
+# Fetching information
+current_version=$(cat manifest.json | jq -j '.version|split("~")[0]')
+repo=$(cat manifest.json | jq -j '.upstream.code|split("https://github.com/")[1]')
+# Some jq magic is needed, because the latest upstream release is not always the latest version (e.g. security patches for older versions)
+version=$(curl --silent "https://api.github.com/repos/$repo/releases" | jq -r '.[] | select( .prerelease != true ) | .tag_name' | sort -V | tail -1)
+assets="https://github.com/tootsuite/mastodon/archive/refs/tags/$version.tar.gz"
+
+# Later down the script, we assume the version has only digits and dots
+# Sometimes the release name starts with a "v", so let's filter it out.
+# You may need more tweaks here if the upstream repository has different naming conventions. 
+if [[ ${version:0:1} == "v" || ${version:0:1} == "V" ]]; then
+    version=${version:1}
+fi
+
+# Setting up the environment variables
+echo "Current version: $current_version"
+echo "Latest release from upstream: $version"
+echo "VERSION=$version" >> $GITHUB_ENV
+# For the time being, let's assume the script will fail
+echo "PROCEED=false" >> $GITHUB_ENV
+
+# Proceed only if the retrieved version is greater than the current one
+if ! dpkg --compare-versions "$current_version" "lt" "$version" ; then
+    echo "::warning ::No new version available"
+    exit 0
+fi
+# Proceed only if a PR for this new version does not already exist
+elif git ls-remote -q --exit-code --heads https://github.com/$GITHUB_REPOSITORY.git ci-auto-update-v$version ; then
+    echo "::warning ::A branch already exists for this update"
+    exit 0
+fi
+
+#=================================================
+# UPDATE SOURCE FILES
+#=================================================
+
+# Let's download source tarball
+asset_url=$assets
+echo "Handling asset at $asset_url"
+src="app"
+
+# Create the temporary directory
+tempdir="$(mktemp -d)"
+
+# Download sources and calculate checksum
+filename=${asset_url##*/}
+curl --silent -4 -L $asset_url -o "$tempdir/$filename"
+checksum=$(sha256sum "$tempdir/$filename" | head -c 64)
+
+# Delete temporary directory
+rm -rf $tempdir
+
+# Get extension
+if [[ $filename == *.tar.gz ]]; then
+  extension=tar.gz
+else
+  extension=${filename##*.}
+fi
+
+# Rewrite source file
+cat <<EOT > conf/$src.src
+SOURCE_URL=$asset_url
+SOURCE_SUM=$checksum
+SOURCE_SUM_PRG=sha256sum
+SOURCE_FORMAT=$extension
+SOURCE_IN_SUBDIR=true
+SOURCE_FILENAME=
+EOT
+echo "... conf/$src.src updated"
+
+#
+#=================================================
+# SPECIFIC UPDATE STEPS
+#=================================================
+
+# Any action on the app's source code can be done.
+# The GitHub Action workflow takes care of committing all changes after this script ends.
+
+#=================================================
+# GENERIC FINALIZATION
+#=================================================
+
+# Replace new version in manifest
+echo "$(jq -s --indent 4 ".[] | .version = \"$version~ynh1\"" manifest.json)" > manifest.json
+
+# No need to update the README, yunohost-bot takes care of it
+
+# The Action will proceed only if the PROCEED environment variable is set to true
+echo "PROCEED=true" >> $GITHUB_ENV
+exit 0

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -1,0 +1,49 @@
+# This workflow allows GitHub Actions to automagically update your app whenever a new upstream release is detected.
+# You need to enable Actions in your repository settings, and fetch this Action from the YunoHost-Apps organization.
+# This file should be enough by itself, but feel free to tune it to your needs.
+# It calls updater.sh, which is where you should put the app-specific update steps.
+name: Check for new upstream releases
+on:
+  # Allow to manually trigger the workflow
+  workflow_dispatch:
+  # Run it every day at 6:00 UTC
+  schedule:
+    - cron:  '0 6 * * *'
+jobs:
+  updater:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch the source code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run the updater script
+        id: run_updater
+        run: |
+          # Setting up Git user
+          git config --global user.name 'yunohost-bot'
+          git config --global user.email 'yunohost-bot@users.noreply.github.com'
+          # Run the updater script
+          /bin/bash .github/workflows/updater.sh
+      - name: Commit changes
+        id: commit
+        if: ${{ env.PROCEED == 'true' }}
+        run: |
+          git commit -am "Upgrade to v$VERSION"
+      - name: Create Pull Request
+        id: cpr
+        if: ${{ env.PROCEED == 'true' }}
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update to version ${{ env.VERSION }}
+          committer: 'yunohost-bot <yunohost-bot@users.noreply.github.com>'
+          author: 'yunohost-bot <yunohost-bot@users.noreply.github.com>'
+          signoff: false
+          base: testing
+          branch: ci-auto-update-v${{ env.VERSION }}
+          delete-branch: true
+          title: 'Upgrade to version ${{ env.VERSION }}'
+          body: |
+            Upgrade to v${{ env.VERSION }}
+          draft: false

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,7 +1,6 @@
-SOURCE_URL=https://github.com/tootsuite/mastodon/archive/refs/tags/v3.4.4.tar.gz
-SOURCE_SUM=567e57cc9d35306cbd708a33bc0bf1adf7981f3706ca4eced0d0c2b4f980034d
+SOURCE_URL=https://github.com/tootsuite/mastodon/archive/refs/tags/v3.4.5.tar.gz
+SOURCE_SUM=425d276f655cc5749a8a590d449c7ef39b22a2f88b1977ac11a70eb2d7f522fa
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
 SOURCE_FILENAME=
-SOURCE_EXTRACT=true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Libre and federated social network",
         "fr": "Réseau social libre et fédéré"
     },
-    "version": "3.4.4~ynh3",
+    "version": "3.4.5~ynh1",
     "url": "https://github.com/mastodon/mastodon",
     "upstream": {
         "license": "AGPL-3.0-or-later",
@@ -37,7 +37,7 @@
         "nginx"
     ],
     "arguments": {
-        "install" : [
+        "install": [
             {
                 "name": "domain",
                 "type": "domain"
@@ -57,8 +57,11 @@
                 "ask": {
                     "en": "Choose the application language",
                     "fr": "Choisissez la langue de l'application"
-            },
-                "choices": ["en_EN", "fr_FR"],
+                },
+                "choices": [
+                    "en_EN",
+                    "fr_FR"
+                ],
                 "default": "fr_FR"
             }
         ]


### PR DESCRIPTION
## Problem

New Mastodon release https://github.com/mastodon/mastodon/releases/tag/v3.4.5
> ⚠️ Mastodon v3.3.2 and v3.4.6 will be released on **Thursday, February 3rd**, between 13:00 and 15:00 UTC, fixing a variety of bugs, including a **critical security issue**.
> 
> To make applying the fixes easier, you can prepare by updating to Mastodon v3.4.5 (or v3.3.1), as migrating from this bugfix release will require no dependency update, no database migration and no assets compilation.

## Solution

- Port the updater.sh to mastodon
- Update to 3.4.5

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

[![Test Badge](https://img.shields.io/endpoint?url=https://bleu.cant.at/ci/api/job/6/badge)](https://bleu.cant.at/ci/job/6)
[![](https://bleu.cant.at/ci/summary/6.png)](https://bleu.cant.at/ci/job/6)
