### PR TITLE
fix: add a missing user field in cron file (aka fix the cron again o/)

### DIFF
--- a/conf/cron
+++ b/conf/cron
@@ -1,5 +1,7 @@
-@daily cd __FINAL_PATH__/live && sudo -u __APP__ __YNH_RUBY_LOAD_PATH__ __LD_PRELOAD__ RAILS_ENV=production bin/tootctl media remove
-@monthly cd __FINAL_PATH__/live && sudo -u __APP__ __YNH_RUBY_LOAD_PATH__ __LD_PRELOAD__ RAILS_ENV=production bin/tootctl media remove-orphans
-@monthly cd __FINAL_PATH__/live && sudo -u __APP__ __YNH_RUBY_LOAD_PATH__ __LD_PRELOAD__ RAILS_ENV=production bin/tootctl accounts cull
-@monthly cd __FINAL_PATH__/live && sudo -u __APP__ __YNH_RUBY_LOAD_PATH__ __LD_PRELOAD__ RAILS_ENV=production bin/tootctl statuses remove
-@monthly cd __FINAL_PATH__/live && sudo -u __APP__ __YNH_RUBY_LOAD_PATH__ __LD_PRELOAD__ RAILS_ENV=production bin/tootctl preview_cards remove
+# This is a system cron file, see crontab(5)
+# m h dom mon dow user command
+@daily __APP__ cd __FINAL_PATH__/live && __YNH_RUBY_LOAD_PATH__ __LD_PRELOAD__ RAILS_ENV=production bin/tootctl media remove
+@monthly __APP__ cd __FINAL_PATH__/live && __YNH_RUBY_LOAD_PATH__ __LD_PRELOAD__ RAILS_ENV=production bin/tootctl media remove-orphans
+@monthly __APP__ cd __FINAL_PATH__/live && __YNH_RUBY_LOAD_PATH__ __LD_PRELOAD__ RAILS_ENV=production bin/tootctl accounts cull
+@monthly __APP__ cd __FINAL_PATH__/live && __YNH_RUBY_LOAD_PATH__ __LD_PRELOAD__ RAILS_ENV=production bin/tootctl statuses remove
+@monthly __APP__ cd __FINAL_PATH__/live && __YNH_RUBY_LOAD_PATH__ __LD_PRELOAD__ RAILS_ENV=production bin/tootctl preview_cards remove


### PR DESCRIPTION
## Problem

`/etc/cron.d/mastodon` is a "system cron file" and the syntax slightly differ from other cron files. It has a user field which is missing, and the cron tasks fail.
[See on the forum](https://forum.yunohost.org/t/nettoyage-mastodon-sauvegarde/18810/5)

## Solution

Fix the cron file again :partying_face: 

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
