### PR TITLE
fix: add a missing user field in cron file (aka fix the cron again o/)

### DIFF
--- a/.github/workflows/updater.sh
+++ b/.github/workflows/updater.sh
@@ -38,7 +38,6 @@ echo "PROCEED=false" >> $GITHUB_ENV
 if ! dpkg --compare-versions "$current_version" "lt" "$version" ; then
     echo "::warning ::No new version available"
     exit 0
-fi
 # Proceed only if a PR for this new version does not already exist
 elif git ls-remote -q --exit-code --heads https://github.com/$GITHUB_REPOSITORY.git ci-auto-update-v$version ; then
     echo "::warning ::A branch already exists for this update"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 
 Mastodon is a free, open-source microblogging social network. It is a decentralized alternative to commercial platforms like Twitter and avoids the risks of a single company monopolizing your communication for commercial purposes. 
 
-**Shipped version:** 3.4.6~ynh1
+**Shipped version:** 3.4.6~ynh2
 
 **Demo:** https://joinmastodon.org/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -14,7 +14,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 Mastodon est un réseau social de microblog auto-hébergé et open source. C'est une alternative décentralisée aux plates-formes commerciales comme Twitter. Mastodon évite ainsi les risques qu'une seule société monopolise votre communication à des fins commerciales.
 
 
-**Version incluse :** 3.4.6~ynh1
+**Version incluse :** 3.4.6~ynh2
 
 **Démo :** https://joinmastodon.org/
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Libre and federated social network",
         "fr": "Réseau social libre et fédéré"
     },
-    "version": "3.4.6~ynh1",
+    "version": "3.4.6~ynh2",
     "url": "https://github.com/mastodon/mastodon",
     "upstream": {
         "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Problem

`/etc/cron.d/mastodon` is a "system cron file" and the syntax slightly differ from other cron files. It has a user field which is missing, and the cron tasks fail.
[See on the forum](https://forum.yunohost.org/t/nettoyage-mastodon-sauvegarde/18810/5)

## Solution

Fix the cron file again :partying_face: 

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
