### PR TITLE
Upgrade version to match the .ruby-version file

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -9,7 +9,7 @@ pkg_dependencies="imagemagick ffmpeg libpq-dev libxml2-dev libxslt1-dev file git
 build_pkg_dependencies=""
 
 memory_needed="2560"
-ruby_version=2.7.2
+ruby_version=3.0.3
 nodejs_version=12
 
 # Workaround for Mastodon on Bullseye


### PR DESCRIPTION
## Problem

- Fix #332

## Solution

- Upgrade ruby according to https://github.com/mastodon/mastodon/blob/v3.5.3/.ruby-version

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
