### PR TITLE
Stop systemd before upgrading

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -46,6 +46,15 @@ ynh_script_progression --message="Checking version..." --weight=1
 upgrade_type=$(ynh_check_app_version_changed)
 
 #=================================================
+# STOP SYSTEMD SERVICE
+#=================================================
+ynh_script_progression --message="Stopping a systemd service..." --weight=1
+
+ynh_systemd_action --service_name=${app}-web --action="stop" --log_path=systemd --line_match="Stopped"
+ynh_systemd_action --service_name=${app}-sidekiq --action="stop" --log_path=systemd --line_match="Stopped"
+ynh_systemd_action --service_name=${app}-streaming --action="stop" --log_path=systemd --line_match="Stopped"
+
+#=================================================
 # BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
 #=================================================
 ynh_script_progression --message="Backing up the app before upgrading (may take a while)..." --weight=1
@@ -61,15 +70,6 @@ ynh_abort_if_errors
 
 #=================================================
 # STANDARD UPGRADE STEPS
-#=================================================
-# STOP SYSTEMD SERVICE
-#=================================================
-ynh_script_progression --message="Stopping a systemd service..." --weight=1
-
-ynh_systemd_action --service_name=${app}-web --action="stop" --log_path=systemd --line_match="Stopped"
-ynh_systemd_action --service_name=${app}-sidekiq --action="stop" --log_path=systemd --line_match="Stopped"
-ynh_systemd_action --service_name=${app}-streaming --action="stop" --log_path=systemd --line_match="Stopped"
-
 #=================================================
 # ENSURE DOWNWARD COMPATIBILITY
 #=================================================


### PR DESCRIPTION
Since the content of Mastodon is very dynamic, lots of public posts, but also possibly DM and follow-up requests in just a minute, it might be useful during an upgrade to stop the Mastodon service first and then start the backup afterwards.

That way, if something went wrong during the upgrade process, no important messages will be lost.

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)
