### PR TITLE
Patch Gemfile to fix blurhash and ox packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It shall NOT be edited by hand.
 
 # Mastodon for YunoHost
 
-[![Integration level](https://dash.yunohost.org/integration/mastodon.svg)](https://dash.yunohost.org/appci/app/mastodon) ![Working status](https://ci-apps.yunohost.org/ci/badges/mastodon.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/mastodon.maintain.svg)  
+[![Integration level](https://dash.yunohost.org/integration/mastodon.svg)](https://dash.yunohost.org/appci/app/mastodon) ![Working status](https://ci-apps.yunohost.org/ci/badges/mastodon.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/mastodon.maintain.svg)
 [![Install Mastodon with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=mastodon)
 
 *[Lire ce readme en français.](./README_fr.md)*

--- a/README_fr.md
+++ b/README_fr.md
@@ -5,15 +5,15 @@ It shall NOT be edited by hand.
 
 # Mastodon pour YunoHost
 
-[![Niveau d'intégration](https://dash.yunohost.org/integration/mastodon.svg)](https://dash.yunohost.org/appci/app/mastodon) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/mastodon.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/mastodon.maintain.svg)  
+[![Niveau d’intégration](https://dash.yunohost.org/integration/mastodon.svg)](https://dash.yunohost.org/appci/app/mastodon) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/mastodon.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/mastodon.maintain.svg)
 [![Installer Mastodon avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=mastodon)
 
 *[Read this readme in english.](./README.md)*
 
-> *Ce package vous permet d'installer Mastodon rapidement et simplement sur un serveur YunoHost.
-Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour savoir comment l'installer et en profiter.*
+> *Ce package vous permet d’installer Mastodon rapidement et simplement sur un serveur YunoHost.
+Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour savoir comment l’installer et en profiter.*
 
-## Vue d'ensemble
+## Vue d’ensemble
 
 Mastodon est un réseau social de microblog auto-hébergé et open source. C'est une alternative décentralisée aux plates-formes commerciales comme Twitter. Mastodon évite ainsi les risques qu'une seule société monopolise votre communication à des fins commerciales.
 
@@ -22,9 +22,9 @@ Mastodon est un réseau social de microblog auto-hébergé et open source. C'est
 
 **Démo :** https://joinmastodon.org/
 
-## Captures d'écran
+## Captures d’écran
 
-![Capture d'écran de Mastodon](./doc/screenshots/mastodon.png)
+![Capture d’écran de Mastodon](./doc/screenshots/mastodon.png)
 
 ## Avertissements / informations importantes
 
@@ -76,9 +76,9 @@ Se déconnecter depuis le portail YunoHost ne vous déconnecte pas de Mastodon. 
 
 ## Documentations et ressources
 
-* Site officiel de l'app : <https://joinmastodon.org/>
-* Documentation officielle de l'admin : <https://docs.joinmastodon.org/>
-* Dépôt de code officiel de l'app : <https://github.com/mastodon/mastodon>
+* Site officiel de l’app : <https://joinmastodon.org/>
+* Documentation officielle de l’admin : <https://docs.joinmastodon.org/>
+* Dépôt de code officiel de l’app : <https://github.com/mastodon/mastodon>
 * Documentation YunoHost pour cette app : <https://yunohost.org/app_mastodon>
 * Signaler un bug : <https://github.com/YunoHost-Apps/mastodon_ynh/issues>
 
@@ -94,4 +94,4 @@ ou
 sudo yunohost app upgrade mastodon -u https://github.com/YunoHost-Apps/mastodon_ynh/tree/testing --debug
 ```
 
-**Plus d'infos sur le packaging d'applications :** <https://yunohost.org/packaging_apps>
+**Plus d’infos sur le packaging d’applications :** <https://yunohost.org/packaging_apps>

--- a/sources/patches/app-blurhash-bugfix.patch
+++ b/sources/patches/app-blurhash-bugfix.patch
@@ -1,0 +1,60 @@
+diff --git a/Gemfile b/Gemfile
+index 7c36bc6b8..3f691d102 100644
+--- a/Gemfile
++++ b/Gemfile
+@@ -22,7 +22,8 @@
+ gem 'fog-core', '<= 2.1.0'
+ gem 'fog-openstack', '~> 0.3', require: false
+ gem 'kt-paperclip', '~> 7.1'
+-gem 'blurhash', '~> 0.1'
++gem 'blurhash', github: 'Gargron/blurhash', ref: '870a34e01ce7d09a7bd4d700435e1764ca823246'
++
+ 
+ gem 'active_model_serializers', '~> 0.10'
+ gem 'addressable', '~> 2.8'
+
+diff --git a/Gemfile.lock b/Gemfile.lock
+index 7c36bc6b8..3f691d102 100644
+--- a/Gemfile.lock
++++ b/Gemfile.lock
+@@ -7,6 +7,13 @@
+       hkdf (~> 0.2)
+       jwt (~> 2.0)
+ 
++GIT
++  remote: https://github.com/Gargron/blurhash.git
++  revision: 870a34e01ce7d09a7bd4d700435e1764ca823246
++  ref: 870a34e01ce7d09a7bd4d700435e1764ca823246
++  specs:
++    blurhash (0.1.6)
++
+ GEM
+   remote: https://rubygems.org/
+   specs:
+@@ -120,8 +127,6 @@
+     bindata (2.4.10)
+     binding_of_caller (1.0.0)
+       debug_inspector (>= 0.0.1)
+-    blurhash (0.1.6)
+-      ffi (~> 1.14)
+     bootsnap (1.13.0)
+       msgpack (~> 1.2)
+     brakeman (5.3.1)
+@@ -448,7 +453,7 @@
+     openssl-signature_algorithm (1.2.1)
+       openssl (> 2.0, < 3.1)
+     orm_adapter (0.5.0)
+-    ox (2.14.11)
++    ox (2.14.13)
+     parallel (1.22.1)
+     parser (3.1.2.1)
+       ast (~> 2.4.1)
+@@ -738,7 +743,7 @@
+   aws-sdk-s3 (~> 1.114)
+   better_errors (~> 2.9)
+   binding_of_caller (~> 1.0)
+-  blurhash (~> 0.1)
++  blurhash!
+   bootsnap (~> 1.13.0)
+   brakeman (~> 5.3)
+   browser


### PR DESCRIPTION
## Problem

Mastodon wasn't installing (or upgrading) properly because the `blurhash` package was broken with newer versions of Ruby/gem. This has been described in several issues, including in https://github.com/YunoHost-Apps/mastodon_ynh/issues/357

Additionally, using the fixed version of `blurhash` created similar errors with `ox` as described in https://github.com/ohler55/ox/issues/300

Close #357 

## Solution

Fixes have been made to both `blurhash` (https://github.com/Gargron/blurhash/pull/20) and `ox` (https://github.com/ohler55/ox/pull/301). However, these are yet to make it to a new release. To make Mastodon work before that, I've patched `Gemfile` and `Gemfile.lock` to install the two packages directly from their respective git repos. (I've locked them to the specific commits of the fixes, so we won't unintentionally add other updates as well).

If this PR is accepted, we should probably leave a note somewhere to remove the patch when newer versions of `blurhash` and `ox` come out.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
