### PR TITLE
Add support for LOCAL_DOMAIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ $ screen -d
 $ screen -r
 ```
 
+#### Using separate domains for Serving and Identity
+
+It is possible to use one domain for serving (like social.example.com) and another for the user identities (like @user@example.com).
+In this installation simple set the Local Domain field with the relevant domain.
+If the Identity domain is locally managed and properly entered, appropriate redirects will be set up, otherwise you will need to set them up manually.
+
+Example of setting up the required redirect in nginx:
+```
+{
+  server example.com;
+  # Other example.com settings...
+  ### This is the relevant part:
+  location ~ ^/.well-known/(host-meta|nodeinfo|webfinger)/ {
+    return 301 https://__DOMAIN__$request_uri;
+  }
+  ### Until here is the relevant part
+}
+```
+
 ### Update
 
 #### Using *screen* highly recommended

--- a/conf/.env.production.sample
+++ b/conf/.env.production.sample
@@ -14,7 +14,8 @@
 # ----------
 # This identifies your server and cannot be changed safely later
 # ----------
-LOCAL_DOMAIN=__DOMAIN__
+LOCAL_DOMAIN=__LOCAL_DOMAIN__
+WEB_DOMAIN=__DOMAIN__
 
 # Redis
 # -----

--- a/conf/well_known.conf
+++ b/conf/well_known.conf
@@ -1,3 +1,3 @@
-location ~ ^/.well-known/(host-meta|nodeinfo|webfinger)/ {
+location ~ ^/.well-known/(host-meta|nodeinfo|webfinger) {
   return 301 https://__DOMAIN__$request_uri;
 }

--- a/conf/well_known.conf
+++ b/conf/well_known.conf
@@ -1,0 +1,3 @@
+location ~ ^/.well-known/(host-meta|nodeinfo|webfinger)/ {
+  return 301 https://__DOMAIN__$request_uri;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Libre and federated social network",
         "fr": "Réseau social libre et fédéré"
     },
-    "version": "4.0.2~ynh2",
+    "version": "4.0.2~ynh3",
     "url": "https://github.com/mastodon/mastodon",
     "upstream": {
         "license": "AGPL-3.0-or-later",
@@ -44,7 +44,8 @@
             },
             {
                 "name": "local_domain",
-                "type": "string",
+                "type": "domain",
+                "optional": true,
                 "default": "",
                 "ask": {
                     "en": "What domain do you want to ues for users?"

--- a/manifest.json
+++ b/manifest.json
@@ -44,14 +44,13 @@
             },
             {
                 "name": "local_domain",
-                "type": "domain",
-                "optional": true,
-                "default": "",
+                "type": "string",
+                "default": "Same as the domain",
                 "ask": {
-                    "en": "What domain do you want to ues for users?"
+                    "en": "Local Domain: Set a different domain for user identity"
                 },
                 "help": {
-                    "en": "Use a different domain for users than the installation domain, you'll need to setup the well-known redirects your self"
+                    "en": "You can specify another domain so users are referred to @user@domain.tld instead of @user@social.domain.tld. URL redirects will automatically be created if the domain is locally managed."
                 }
             },
             {

--- a/manifest.json
+++ b/manifest.json
@@ -44,10 +44,13 @@
             },
             {
                 "name": "local_domain",
-                "type": "domain",
+                "type": "string",
                 "default": "",
+                "ask": {
+                    "en": "What domain do you want to ues for users?"
+                },
                 "help": {
-                    "en": "Use a different domain for users than the installation domain"
+                    "en": "Use a different domain for users than the installation domain, you'll need to setup the well-known redirects your self"
                 }
             },
             {

--- a/manifest.json
+++ b/manifest.json
@@ -43,6 +43,14 @@
                 "type": "domain"
             },
             {
+                "name": "local_domain",
+                "type": "domain",
+                "default": "",
+                "help": {
+                    "en": "Use a different domain for users than the installation domain"
+                }
+            },
+            {
                 "name": "is_public",
                 "type": "boolean",
                 "default": true

--- a/scripts/backup
+++ b/scripts/backup
@@ -29,6 +29,7 @@ app=$YNH_APP_INSTANCE_NAME
 
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 domain=$(ynh_app_setting_get --app=$app --key=domain)
+local_domain=$(ynh_app_setting_get --app=$app --key=local_domain)
 db_name=$(ynh_app_setting_get --app=$app --key=db_name)
 
 #=================================================
@@ -47,6 +48,9 @@ ynh_backup --src_path="$final_path"
 #=================================================
 
 ynh_backup --src_path="/etc/nginx/conf.d/$domain.d/$app.conf"
+if [[ "$domain" != "$local_domain" ]] && yunohost --output-as plain domain list | grep -q "^$local_domain$"; then
+  ynh_backup --src_path="/etc/nginx/conf.d/${local_domain}.d/${app}_well_known.conf"
+fi
 
 #=================================================
 # SPECIFIC BACKUP

--- a/scripts/install
+++ b/scripts/install
@@ -26,7 +26,7 @@ ynh_abort_if_errors
 #=================================================
 
 domain=$YNH_APP_ARG_DOMAIN
-local_domain=${YNH_APP_ARG_LOCAL_DOMAIN:=$YNH_APP_ARG_DOMAIN}
+local_domain=$YNH_APP_ARG_LOCAL_DOMAIN
 path_url="/"
 is_public=$YNH_APP_ARG_IS_PUBLIC
 language=$YNH_APP_ARG_LANGUAGE
@@ -35,6 +35,11 @@ admin=$YNH_APP_ARG_ADMIN
 app=$YNH_APP_INSTANCE_NAME
 
 admin_mail=$(ynh_user_get_info --username=$admin --key=mail)
+
+# Serving domain is identical to Identity domain
+if [[ "$local_domain" == "Same as the domain" ]]; then
+  local_domain=$domain
+fi
 
 #=================================================
 # CHECK IF THE APP CAN BE INSTALLED WITH THESE ARGS
@@ -121,6 +126,11 @@ chown -R $app:www-data "$final_path"
 # NGINX CONFIGURATION
 #=================================================
 ynh_script_progression --message="Configuring NGINX web server..." --weight=1
+
+# Create .well-known redirection for access by federation, if Identity domain is different from Serving domain
+if [[ "$domain" != "$local_domain" ]] && yunohost --output-as plain domain list | grep -q "^$local_domain$"; then
+  ynh_add_config --template="well_known.conf" --destination="/etc/nginx/conf.d/${local_domain}.d/${app}_well_known.conf"
+fi
 
 # Create a dedicated NGINX config
 ynh_add_nginx_config
@@ -269,6 +279,13 @@ then
 fi
 
 ynh_permission_create --permission="api" --url="/api" --allowed="visitors" --auth_header="false" --show_tile="false" --protected="true"
+
+# Create .well-known redirection for access by federation, if Identity domain is different from Serving domain
+if [[ "$domain" != "$local_domain" ]] && yunohost --output-as plain domain list | grep -q "^$local_domain$"; then
+  ynh_permission_create --permission=well_known --url=$local_domain/.well-known/webfinger \
+                        --additional_urls $local_domain/.well-known/host-meta $local_domain/.well-known/nodeinfo \
+                        --label="Well known path redirects" --show_tile=false --allowed=visitors --auth_header=false
+fi
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/install
+++ b/scripts/install
@@ -26,6 +26,7 @@ ynh_abort_if_errors
 #=================================================
 
 domain=$YNH_APP_ARG_DOMAIN
+local_domain=${YNH_APP_ARG_LOCAL_DOMAIN:=$YNH_APP_ARG_DOMAIN}
 path_url="/"
 is_public=$YNH_APP_ARG_IS_PUBLIC
 language=$YNH_APP_ARG_LANGUAGE
@@ -52,6 +53,7 @@ ynh_webpath_register --app=$app --domain=$domain --path_url=$path_url
 ynh_script_progression --message="Storing installation settings..." --weight=1
 
 ynh_app_setting_set --app=$app --key=domain --value=$domain
+ynh_app_setting_set --app=$app --key=local_domain --value=$local_domain
 ynh_app_setting_set --app=$app --key=path --value=$path_url
 ynh_app_setting_set --app=$app --key=language --value=$language
 ynh_app_setting_set --app=$app --key=admin --value=$admin

--- a/scripts/remove
+++ b/scripts/remove
@@ -19,6 +19,7 @@ ynh_script_progression --message="Loading installation settings..." --weight=1
 app=$YNH_APP_INSTANCE_NAME
 
 domain=$(ynh_app_setting_get --app=$app --key=domain)
+local_domain=$(ynh_app_setting_get --app=$app --key=local_domain)
 db_name=$(ynh_app_setting_get --app=$app --key=db_name)
 db_user=$(ynh_app_setting_get --app=$app --key=db_user)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)

--- a/scripts/remove
+++ b/scripts/remove
@@ -80,6 +80,9 @@ ynh_secure_remove --file="$final_path"
 #=================================================
 ynh_script_progression --message="Removing NGINX web server configuration..." --weight=1
 
+# Remove well known path redirects if installed
+ynh_secure_remove --file="/etc/nginx/conf.d/${local_domain}.d/${app}_well_known.conf"
+
 # Remove the dedicated NGINX config
 ynh_remove_nginx_config
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -30,6 +30,7 @@ ynh_script_progression --message="Loading installation settings..." --weight=1
 app=$YNH_APP_INSTANCE_NAME
 
 domain=$(ynh_app_setting_get --app=$app --key=domain)
+local_domain=$(ynh_app_setting_get --app=$app --key=local_domain)
 path_url=$(ynh_app_setting_get --app=$app --key=path)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 db_name=$(ynh_app_setting_get --app=$app --key=db_name)

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -19,6 +19,7 @@ ynh_script_progression --message="Loading installation settings..." --weight=1
 app=$YNH_APP_INSTANCE_NAME
 
 domain=$(ynh_app_setting_get --app=$app --key=domain)
+local_domain=$(ynh_app_setting_get --app=$app --key=local_domain)
 path_url=$(ynh_app_setting_get --app=$app --key=path)
 language=$(ynh_app_setting_get --app=$app --key=language)
 admin=$(ynh_app_setting_get --app=$app --key=admin)

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -18,8 +18,9 @@ ynh_script_progression --message="Loading installation settings..." --weight=1
 
 app=$YNH_APP_INSTANCE_NAME
 
+_local_domain=$(ynh_app_setting_get --app=$app --key=local_domain)
 domain=$(ynh_app_setting_get --app=$app --key=domain)
-local_domain=$(ynh_app_setting_get --app=$app --key=local_domain)
+local_domain=${_local_domain:=$domain}
 path_url=$(ynh_app_setting_get --app=$app --key=path)
 language=$(ynh_app_setting_get --app=$app --key=language)
 admin=$(ynh_app_setting_get --app=$app --key=admin)

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -18,9 +18,8 @@ ynh_script_progression --message="Loading installation settings..." --weight=1
 
 app=$YNH_APP_INSTANCE_NAME
 
-_local_domain=$(ynh_app_setting_get --app=$app --key=local_domain)
 domain=$(ynh_app_setting_get --app=$app --key=domain)
-local_domain=${_local_domain:=$domain}
+local_domain=$(ynh_app_setting_get --app=$app --key=local_domain)
 path_url=$(ynh_app_setting_get --app=$app --key=path)
 language=$(ynh_app_setting_get --app=$app --key=language)
 admin=$(ynh_app_setting_get --app=$app --key=admin)
@@ -151,6 +150,19 @@ if [[ -z "$redis_namespace" ]]; then
 	ynh_app_setting_set --app=$app --key=redis_namespace --value=$redis_namespace
 fi
 
+# Update settings when upgrading from a setup with no local_domain
+if [[ -z $local_domain ]]; then
+  local_domain=$domain
+  ynh_app_setting_set --app=$app --key=local_domain --value=$domain
+fi
+
+# Create .well-known redirection for access by federation, if Identity domain is different from Serving domain
+if [[ "$domain" != "$local_domain" ]] && yunohost --output-as plain domain list | grep -q "^$local_domain$" && ! ynh_permission_exists --permission="well_known"; then
+  ynh_permission_create --permission=well_known --url=$local_domain/.well-known/webfinger \
+                        --additional_urls $local_domain/.well-known/host-meta $local_domain/.well-known/nodeinfo \
+                        --label="Well known path redirects" --show_tile=false --allowed=visitors --auth_header=false
+fi
+
 #Remove previous added repository
 ynh_remove_extra_repo
 
@@ -210,6 +222,11 @@ ynh_exec_warn_less ynh_install_extra_app_dependencies --repo="deb https://dl.yar
 # NGINX CONFIGURATION
 #=================================================
 ynh_script_progression --message="Upgrading NGINX web server configuration..." --weight=1
+
+# Create .well-known redirection for access by federation, if Identity domain is different from Serving domain
+if [[ "$domain" != "$local_domain" ]] && yunohost --output-as plain domain list | grep -q "^$local_domain$"; then
+  ynh_add_config --template="well_known.conf" --destination="/etc/nginx/conf.d/${local_domain}.d/${app}_well_known.conf"
+fi
 
 # Create a dedicated NGINX config
 ynh_add_nginx_config


### PR DESCRIPTION
## Problem

I want to install Mastodon on a subdomain while allowing users to use their `user@rootdomain` identity, this is supported by mastodon using the `LOCAL_DOMAIN` environment variable

* Implement what is decided in #372 

## Solution

I added an argument `local_domain` that if empty uses the main `domain` argument

NOTICE: this currently accepts arbitrary `local_domain` value, [since I was unable to have an empty value](https://forum.yunohost.org/t/how-to-do-conditional-arguments-empty-default/23805) from `domain` argument type, which would allow me to add a `.well-known` nginx path handling, meaning that the user will need to add manual `.well-known` redirects ([List of URLs](https://mastodon.gitbook.io/mastodon/dev/routes#.well-known))

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

None
