### PR TITLE
Upgrade to v4.0.4

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/tootsuite/mastodon/archive/refs/tags/v4.0.2.tar.gz
-SOURCE_SUM=70a4d9dcd9b746f6e9ced9b567ee5ad81e530cfaccb7f471259b917c20166309
+SOURCE_URL=https://github.com/mastodon/mastodon/archive/refs/tags/v4.0.4.tar.gz
+SOURCE_SUM=c7574fe5b2ca7e017e45584c49dc9a9c76a26c222afaed450c9cb5c467eba009
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Libre and federated social network",
         "fr": "Réseau social libre et fédéré"
     },
-    "version": "4.0.2~ynh2",
+    "version": "4.0.4~ynh2",
     "url": "https://github.com/mastodon/mastodon",
     "upstream": {
         "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## Problem

- Mastodon version 4.0.4 was released today: https://github.com/mastodon/mastodon/releases/tag/v4.0.4

## Solution

- I updated the relevant files for a drop-in upgrade
- Should also resolve #376 

## PR Status

- [X] Code finished and ready to be reviewed/tested