### PR TITLE
typo s/tooctl/tootctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ screen -r
 
 `$ sudo yunohost app upgrade mastodon -u https://github.com/YunoHost-Apps/mastodon_ynh --debug `
 
-### Administrate with tooctl
+### Administrate with tootctl
 
 `$ (cd /var/www/mastodon/live && sudo -u mastodon RAILS_ENV=production PATH=/opt/rbenv/versions/mastodon/bin bin/tootctl --help)`
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -63,7 +63,7 @@ L'utilisateur admin est créé automatiquement comme : user@domain.tld
 
 `$ sudo yunohost app upgrade mastodon -u https://github.com/YunoHost-Apps/mastodon_ynh --debug `
 
-### Administration avec tooctl
+### Administration avec tootctl
 
 `$ (cd /var/www/mastodon/live && sudo -u mastodon RAILS_ENV=production PATH=/opt/rbenv/versions/mastodon/bin bin/tootctl --help)`
 

--- a/doc/DISCLAIMER.md
+++ b/doc/DISCLAIMER.md
@@ -27,7 +27,7 @@ $ screen -r
 
 `$ sudo yunohost app upgrade mastodon -u https://github.com/YunoHost-Apps/mastodon_ynh --debug `
 
-### Administrate with tooctl
+### Administrate with tootctl
 
 `$ (cd /var/www/mastodon/live && sudo -u mastodon RAILS_ENV=production PATH=/opt/rbenv/versions/mastodon/bin bin/tootctl --help)`
 

--- a/doc/DISCLAIMER_fr.md
+++ b/doc/DISCLAIMER_fr.md
@@ -32,7 +32,7 @@ L'utilisateur admin est créé automatiquement comme : user@domain.tld
 
 `$ sudo yunohost app upgrade mastodon -u https://github.com/YunoHost-Apps/mastodon_ynh --debug `
 
-### Administration avec tooctl
+### Administration avec tootctl
 
 `$ (cd /var/www/mastodon/live && sudo -u mastodon RAILS_ENV=production PATH=/opt/rbenv/versions/mastodon/bin bin/tootctl --help)`
 


### PR DESCRIPTION
just added the missing t in tooctl inside the markdown of readme and disclaimer