### PR TITLE
Prevent swap from being created when running inside a LXC

### DIFF
--- a/scripts/ynh_add_swap
+++ b/scripts/ynh_add_swap
@@ -22,7 +22,7 @@ ynh_add_swap () {
 	# Can't swap inside an LXD
 	if [ "$(systemd-detect-virt)" == "lxc" ]
 	then
-		ynh_print_warn --message="You are inside a LXC container, swap will not be added, but that can cause troubles for the app $app. Please make sure you have more than $size M available RAM."
+		ynh_print_warn --message="You are inside a LXC container, swap will not be added, but that can cause troubles for the app $app. Please make sure you have more than 2.5G available RAM."
 		return
 	fi
 

--- a/scripts/ynh_add_swap
+++ b/scripts/ynh_add_swap
@@ -19,6 +19,13 @@ ynh_add_swap () {
 
  	SD_CARD_CAN_SWAP=${SD_CARD_CAN_SWAP:-0}
 
+	# Can't swap inside an LXD
+	if [ "$(systemd-detect-virt)" == "lxc" ]
+	then
+		ynh_print_warn --message="You are inside a LXC container, swap will not be added, but that can cause troubles for the app $app. Please make sure you have more than $size M available RAM."
+		return
+	fi
+
 	# Swap on SD card only if it's is specified
 	if ynh_is_main_device_a_sd_card && [ "$SD_CARD_CAN_SWAP" == "0" ]
 	then


### PR DESCRIPTION
## Problem

- Close #355 
- Close #354 

## Solution

- Prevent swap from being created when running inside a LXC

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
