### PR TITLE
Bump ruby version to 3.2.3

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Mastodon"
 description.en = "Libre and federated social network"
 description.fr = "Réseau social libre et fédéré"
 
-version = "4.2.10~ynh1"
+version = "4.2.10~ynh2"
 
 maintainers = ["Tagada"]
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 memory_needed="2560"
-ruby_version=3.2.2
+ruby_version=3.2.3
 nodejs_version=20
 
 # Workaround for Mastodon on Bullseye


### PR DESCRIPTION
Fixes #455

Version updated 6 months ago https://github.com/mastodon/mastodon/blob/stable-4.2/.ruby-version

## Problem
 
- tootctl needs ruby v3.2.3

## Solution

- Update ruby version

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
