### PR TITLE
Bump minimal Yunohost compatibility to v12

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -19,7 +19,7 @@ cpe = "cpe:2.3:a:joinmastodon:mastodon"
 fund = "https://joinmastodon.org/sponsors"
 
 [integration]
-yunohost = ">= 11.2.12"
+yunohost = ">= 12.0"
 architectures = "all"
 multi_instance = true
 


### PR DESCRIPTION
Because the lipvips dependency can’t be met on Debian 11 “ Incompatible libvips version (8.10.5-Wed Apr 30 17:29:54 UTC 2025), please install libvips >= 8.13” https://packages.debian.org/search?keywords=libvips-dev

Fixes #515 