### PR TITLE
critical security patch (4.6.4)

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Mastodon"
 description.en = "Libre and federated social network"
 description.fr = "Réseau social libre et fédéré"
 
-version = "4.6.3~ynh1"
+version = "4.6.4~ynh1"
 
 maintainers = []
 
@@ -52,8 +52,8 @@ ram.runtime = "500M"
 [resources]
     [resources.sources]
         [resources.sources.main]
-        url = "https://github.com/mastodon/mastodon/archive/refs/tags/v4.6.3.tar.gz"
-        sha256 = "84a5df07b389e1452b1a8602fa8ef35e362a4a90df79df7b8f930584b634a39e"
+        url = "https://github.com/mastodon/mastodon/archive/refs/tags/v4.6.4.tar.gz"
+        sha256 = "daec715f3edaec2791d0e51e0704e17079395a0618ffa7110c9f6593d0005a96"
         autoupdate.strategy = "latest_github_release"
 
         [resources.sources.redis_migration]


### PR DESCRIPTION
https://github.com/mastodon/mastodon/releases/tag/v4.6.4

- Fix incorrect permission enforcement ([GHSA-7jvv-fhmg-wpfw](https://github.com/mastodon/mastodon/security/advisories/GHSA-7jvv-fhmg-wpfw), [GHSA-hx34-2pfw-2qfj](https://github.com/mastodon/mastodon/security/advisories/GHSA-hx34-2pfw-2qfj))
- Fix SSRF protection bypass via IPv4-compatible IPv6 addresses ([GHSA-vwhj-3g83-v276](https://github.com/mastodon/mastodon/security/advisories/GHSA-vwhj-3g83-v276))

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
